### PR TITLE
[SYCL] Postpone creation of HostKernel copy

### DIFF
--- a/sycl/include/sycl/detail/cg_types.hpp
+++ b/sycl/include/sycl/detail/cg_types.hpp
@@ -235,6 +235,34 @@ public:
 #endif
 };
 
+// the class keeps reference to a lambda allocated externally on stack
+class HostKernelRefBase {
+public:
+  // Return pointer to the lambda object.
+  virtual char *GetPtr() const = 0;
+  virtual std::shared_ptr<HostKernelBase> CopyHostKernel() const = 0;
+  virtual ~HostKernelRefBase() noexcept = default;
+};
+
+template <class KernelType, class KernelArgType, int Dims>
+class HostKernelRef : public HostKernelRefBase {
+  const KernelType &MKernel;
+
+public:
+  HostKernelRef(const KernelType &Kernel) : MKernel(Kernel) {}
+
+  char *GetPtr() const override {
+    return reinterpret_cast<char *>(const_cast<KernelType *>(&MKernel));
+  }
+  virtual std::shared_ptr<HostKernelBase> CopyHostKernel() const override {
+    std::shared_ptr<HostKernelBase> Kernel;
+    Kernel.reset(new HostKernel<KernelType, KernelArgType, Dims>(MKernel));
+    return Kernel;
+  }
+
+  ~HostKernelRef() noexcept override = default;
+};
+
 // This function is needed for host-side compilation to keep kernels
 // instantitated. This is important for debuggers to be able to associate
 // kernel code instructions with source code lines.

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -211,7 +211,15 @@ struct KernelRuntimeInfoWrapper {
   KernelRuntimeInfo MKRInfo;
 
   KernelRuntimeInfoWrapper(const KernelType &KernelFunc)
-    : MHostKernelRef(KernelFunc), MKRInfo(MHostKernelRef) {}
+    : MHostKernelRef(KernelFunc), MKRInfo(MHostKernelRef) {
+    // Instantiating the kernel on the host improves debugging.
+    // Passing this pointer to another translation unit prevents optimization.
+#ifndef NDEBUG
+    // TODO: call library to prevent dropping call due to optimization
+    (void)detail::GetInstantiateKernelOnHostPtr<KernelType, TransformedArgType,
+                                                Dims>();
+#endif
+    }
 };
 
 } // namespace v1

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -185,7 +185,8 @@ public:
   }
 
 private:
-  detail::ABINeutralKernelNameStrT MKernelName;
+  detail::ABINeutralKernelNameStrT MKrenelName;
+  // type-erased reference to kernel lambda
   HostKernelRefBase &MHostKernel;
   detail::DeviceKernelInfo *MDeviceKernelInfoPtr = nullptr;
 };
@@ -197,6 +198,9 @@ template <int Dims, typename LambdaArgType> struct TransformUserItemType {
                          item<Dims>, LambdaArgType>>;
 };
 
+// Wrapper for KernelRuntimeInfo that passed to ABI and instance of reference to
+// a lambda that depends on lambda type and can't be passed to ABI. Keeps them
+// together because MKRInfo refers to MHostKernelRef.
 template<typename KernelType, int Dims, detail::WrapAs WrapAsVal>
 struct KernelRuntimeInfoWrapper {
   using LambdaArgType = sycl::detail::lambda_arg_type<KernelType, item<Dims>>;
@@ -207,6 +211,7 @@ struct KernelRuntimeInfoWrapper {
             typename TransformUserItemType<Dims, LambdaArgType>::type>,
         void>;
 
+  // actual reference to kernel lambda
   HostKernelRef<KernelType, TransformedArgType, Dims> MHostKernelRef;
   KernelRuntimeInfo MKRInfo;
 

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -157,7 +157,7 @@ using KernelParamDescGetterFuncPtr = detail::kernel_param_desc_t (*)(int);
 // extracted from the compile time kernel structures.
 class __SYCL_EXPORT KernelRuntimeInfo {
 public:
-  KernelRuntimeInfo() {}
+  KernelRuntimeInfo(HostKernelRefBase &HostKernel) : MHostKernel(HostKernel) {}
 
   KernelRuntimeInfo(const KernelRuntimeInfo &rhs) = delete;
 
@@ -172,13 +172,10 @@ public:
     return MKernelName;
   }
 
-  std::shared_ptr<detail::HostKernelBase> &HostKernel() { return MHostKernel; }
-  const std::shared_ptr<detail::HostKernelBase> &HostKernel() const {
-    return MHostKernel;
+  std::shared_ptr<detail::HostKernelBase> CopyHostKernel() const {
+    return MHostKernel.CopyHostKernel();
   }
-
-  char *GetKernelFuncPtr() { return (*MHostKernel).getPtr(); }
-  char *GetKernelFuncPtr() const { return (*MHostKernel).getPtr(); }
+  char *GetKernelFuncPtr() const { return MHostKernel.GetPtr(); }
 
   detail::DeviceKernelInfo *&DeviceKernelInfoPtr() {
     return MDeviceKernelInfoPtr;
@@ -189,8 +186,32 @@ public:
 
 private:
   detail::ABINeutralKernelNameStrT MKernelName;
-  std::shared_ptr<detail::HostKernelBase> MHostKernel;
+  HostKernelRefBase &MHostKernel;
   detail::DeviceKernelInfo *MDeviceKernelInfoPtr = nullptr;
+};
+
+template <int Dims, typename LambdaArgType> struct TransformUserItemType {
+  using type = std::conditional_t<
+      std::is_convertible_v<nd_item<Dims>, LambdaArgType>, nd_item<Dims>,
+      std::conditional_t<std::is_convertible_v<item<Dims>, LambdaArgType>,
+                         item<Dims>, LambdaArgType>>;
+};
+
+template<typename KernelType, int Dims, detail::WrapAs WrapAsVal>
+struct KernelRuntimeInfoWrapper {
+  using LambdaArgType = sycl::detail::lambda_arg_type<KernelType, item<Dims>>;
+  using TransformedArgType = std::conditional_t<
+        WrapAsVal == detail::WrapAs::parallel_for,
+        std::conditional_t<
+            std::is_integral<LambdaArgType>::value && Dims == 1, item<Dims>,
+            typename TransformUserItemType<Dims, LambdaArgType>::type>,
+        void>;
+
+  HostKernelRef<KernelType, TransformedArgType, Dims> MHostKernelRef;
+  KernelRuntimeInfo MKRInfo;
+
+  KernelRuntimeInfoWrapper(const KernelType &KernelFunc)
+    : MHostKernelRef(KernelFunc), MKRInfo(MHostKernelRef) {}
 };
 
 } // namespace v1
@@ -3700,30 +3721,8 @@ private:
     }
   }
 
-  template <int Dims, typename LambdaArgType> struct TransformUserItemType {
-    using type = std::conditional_t<
-        std::is_convertible_v<nd_item<Dims>, LambdaArgType>, nd_item<Dims>,
-        std::conditional_t<std::is_convertible_v<item<Dims>, LambdaArgType>,
-                           item<Dims>, LambdaArgType>>;
-  };
-
-  template <typename KernelName, typename KernelType, int Dims,
-            detail::WrapAs WrapAsVal>
-  void ProcessKernelRuntimeInfo(const KernelType &KernelFunc,
-                                detail::v1::KernelRuntimeInfo &KRInfo) const {
-
-    using LambdaArgType = sycl::detail::lambda_arg_type<KernelType, item<Dims>>;
-    using TransformedArgType = std::conditional_t<
-        WrapAsVal == detail::WrapAs::parallel_for,
-        std::conditional_t<
-            std::is_integral<LambdaArgType>::value && Dims == 1, item<Dims>,
-            typename TransformUserItemType<Dims, LambdaArgType>::type>,
-        void>;
-
-    KRInfo.HostKernel().reset(
-        new detail::HostKernel<KernelType, TransformedArgType, Dims>(
-            KernelFunc));
-
+  template <typename KernelName>
+  void ProcessKernelRuntimeInfo(detail::v1::KernelRuntimeInfo &KRInfo) const {
     KRInfo.KernelName() = detail::getKernelName<KernelName>();
     KRInfo.DeviceKernelInfoPtr() = &detail::getDeviceKernelInfo<KernelName>();
   }
@@ -3875,18 +3874,17 @@ private:
                                       detail::code_location::current()) const {
     (void)Props;
     detail::tls_code_loc_t TlsCodeLocCapture(CodeLoc);
-    detail::v1::KernelRuntimeInfo KRInfo{};
+    detail::v1::KernelRuntimeInfoWrapper<KernelType, Dims, WrapAsVal> KInfoWrapper{KernelFunc};
 
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
 
-    ProcessKernelRuntimeInfo<NameT, KernelType, Dims, WrapAsVal>(KernelFunc,
-                                                                 KRInfo);
+    ProcessKernelRuntimeInfo<NameT>(KInfoWrapper.MKRInfo);
 
     detail::KernelWrapper<WrapAsVal, NameT, KernelType, ElementType,
                           PropertiesT>::wrap(KernelFunc);
 
-    return submit_kernel_direct_with_event_impl(Range, KRInfo,
+    return submit_kernel_direct_with_event_impl(Range, KInfoWrapper.MKRInfo,
                                                 TlsCodeLocCapture.query(),
                                                 TlsCodeLocCapture.isToplevel());
   }
@@ -3899,18 +3897,18 @@ private:
           detail::code_location::current()) const {
     (void)Props;
     detail::tls_code_loc_t TlsCodeLocCapture(CodeLoc);
-    detail::v1::KernelRuntimeInfo KRInfo{};
+    detail::v1::KernelRuntimeInfoWrapper<KernelType, Dims,
+                             detail::WrapAs::parallel_for> KInfoWrapper{KernelFunc};
 
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
 
-    ProcessKernelRuntimeInfo<NameT, KernelType, Dims,
-                             detail::WrapAs::parallel_for>(KernelFunc, KRInfo);
+    ProcessKernelRuntimeInfo<NameT>(KInfoWrapper.MKRInfo);
 
     detail::KernelWrapper<detail::WrapAs::parallel_for, NameT, KernelType,
                           sycl::nd_item<Dims>, PropertiesT>::wrap(KernelFunc);
 
-    submit_kernel_direct_without_event_impl(Range, KRInfo,
+    submit_kernel_direct_without_event_impl(Range, KInfoWrapper.MKRInfo,
                                             TlsCodeLocCapture.query(),
                                             TlsCodeLocCapture.isToplevel());
   }

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -536,13 +536,19 @@ detail::EventImplPtr queue_impl::submit_kernel_direct_impl(
       std::vector<std::shared_ptr<const void>> AuxiliaryResources;
       bool DiscardEvent = false;
 
+      // At this point, KRInfo.HostKernel() points to the lambda function
+      // allocated on stack. To have pointer valid after submission, we need to
+      // put it in dynamic memory.
+      std::shared_ptr<detail::HostKernelBase> HostKernel =
+          KRInfo.CopyHostKernel();
+
       Args = extractArgsAndReqsFromLambda(
-          KRInfo.GetKernelFuncPtr(),
+          HostKernel->getPtr(),
           KRInfo.DeviceKernelInfoPtr()->ParamDescGetter,
           KRInfo.DeviceKernelInfoPtr()->NumParams);
 
       CommandGroup.reset(new detail::CGExecKernel(
-          std::move(NDRDesc), KRInfo.HostKernel(),
+          std::move(NDRDesc), std::move(HostKernel),
           nullptr, // MKernel
           nullptr, // MKernelBundle
           std::move(CGData), std::move(Args),


### PR DESCRIPTION
Do not create copy of HostKernel till it became used out of submit stack. Do type erasure for lambda via vptr in HostKernelRefBase.